### PR TITLE
changed tweet signature to have optional components

### DIFF
--- a/twitter/twitter_connector.bal
+++ b/twitter/twitter_connector.bal
@@ -17,13 +17,27 @@
 import ballerina/io;
 import ballerina/mime;
 
-public function TwitterConnector::tweet (string status, string mediaIds, string attachmentUrl)
+public function TwitterConnector::tweet (string status, string... args)
     returns Status | TwitterError {
 
     endpoint http:Client clientEndpoint = self.clientEndpoint;
+
     http:Request request;
     TwitterError twitterError = {};
 
+    
+	string mediaIds = "";
+	string attachmentUrl = "";
+	
+    
+	if ((lengthof args) > 0) {
+		mediaIds = args[0];
+	}
+	if ((lengthof args) > 1) {
+		attachmentUrl = args[1];
+	}
+    io:println("mediaIds :"+":");
+    io:println("attachmentUrl :"+":");
     string tweetPath = "/1.1/statuses/update.json";
     string encodedStatusValue = check http:encode(status, "UTF-8");
     string urlParams =  "status=" + encodedStatusValue + "&";

--- a/twitter/twitter_types.bal
+++ b/twitter/twitter_types.bal
@@ -26,11 +26,8 @@ public type TwitterConnector object {
 
     documentation {Update the authenticated user's current status (If you want to provide attachment, you can use
         mediaIds or attachmentUrl)
-        P{{status}} The text of status update
-        P{{mediaIds}} A comma-delimited list of media_ids to associate with the Tweet.
-        P{{attachmentUrl}} Provide a URL as a Tweet attachment.
         returns Status object if successful else Error occured during HTTP client invocation.}
-    public function tweet (string status, string mediaIds, string attachmentUrl) returns Status | error;
+    public function tweet (string status, string... args) returns Status | error;
 
     documentation {Retweet a tweet
         P{{id}} The numerical ID of the desired status


### PR DESCRIPTION
## Purpose
This should resolve issue #30 
https://github.com/wso2-ballerina/package-twitter/issues/30

## Goals
Make optional parameters be actually optional to simplify the interface

## Approach
Updates the signature of the tweet method to use (string...) for optional parameters

## User stories


## Release note

## Documentation

## Training

## Certification

## Marketing

## Automation tests

## Security checks

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 
## Learning
